### PR TITLE
CLI: Fix report cmd TypeError when specifying a non-existing output directory

### DIFF
--- a/devicetiming
+++ b/devicetiming
@@ -129,7 +129,7 @@ var commands = {
 	    return overwriteThenStartServer(true);
 	}
         // Ask "are you for seriously?" then add instrumentation
-        confirm(dangerMessage(targetFiles, targetPath), overwriteThenStartServer); 
+        confirm(dangerMessage(targetFiles, targetPath), overwriteThenStartServer);
     },
 
     // Generate a static report from a results.json file
@@ -146,6 +146,7 @@ var commands = {
             outputPath.split(path.sep).forEach(function(part, i){
                 var p = outputPath.split(path.sep);
                 p.splice(i);
+                p = p.join(path.sep);
                 if (!fs.existsSync(path.resolve(p, part))) {
                     fs.mkdirSync(path.resolve(p, part));
                 }


### PR DESCRIPTION
[path.resolve](https://nodejs.org/docs/latest/api/path.html#path_path_resolve_from_to) expects all arguments to be strings resulting in a TypeError being thrown. Joining the directory parts fixes this.